### PR TITLE
Moves some framework functionality out of bootstrap.php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,23 +17,12 @@ use Auryn\Injector;
 
 return function(Injector $injector, Config $config) {
 
-    $demoTemplates = $config[ConfigDirective::ROOT_DIR] . '/src/LabradorGuide/_templates';
-    $docDir = $config[ConfigDirective::ROOT_DIR] . '/doc';
-    (new \LabradorGuide\Service\ControllerRegister($demoTemplates, $docDir))->register($injector);
-
     // This service register MUST be ran OR you MUST provide an instance of
     // Labrador\Application to the $provider with appropriate dependencies defined
     (new DefaultServicesRegister())->register($injector);
-
-    if ($config[ConfigDirective::ENVIRONMENT] === 'development') {
-        (new DevelopmentServiceRegister($config[ConfigDirective::ROOT_DIR]  . '/.git'))->register($injector);
-    }
 
     if ($config['ini'] instanceof Config) {
         (new IniSetBootstrap($config['ini']))->run();
     }
 
-    if ($config[\Labrador\ConfigDirective::ENVIRONMENT] === 'development') {
-        $injector->make('Labrador\\Development\\HtmlToolbar')->registerEventListeners();
-    }
 };

--- a/src/Labrador/Bootstrap/FrontControllerBootstrap.php
+++ b/src/Labrador/Bootstrap/FrontControllerBootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * A bootstrap that will register all services and run all other bootstraps.
+ * Creates the Auryn Injector, primary configuration and boots up the application.
  * 
  * @license See LICENSE in source root
  * @version 1.0
@@ -32,7 +32,7 @@ class FrontControllerBootstrap implements Bootstrap {
     }
 
     /**
-     * @return Provider|mixed
+     * @return Provider
      * @throws \Labrador\Exception\BootupException
      */
     function run() {
@@ -42,15 +42,16 @@ class FrontControllerBootstrap implements Bootstrap {
         $configCb = $this->configCb;
         $configCb($config);
 
+        $injector->share($config);
         $this->runBootstrap($injector, $config);
 
         return $injector;
     }
 
     private function runBootstrap(Injector $injector, Config $config) {
-        $bootstraps = $config[ConfigDirective::BOOTSTRAP_CALLBACK];
-        if (is_callable($bootstraps)) {
-            $bootstraps($injector, $config);
+        $bootstrap = $config[ConfigDirective::BOOTSTRAP_CALLBACK];
+        if (is_callable($bootstrap)) {
+            $bootstrap($injector, $config);
         }
     }
 

--- a/src/Labrador/Development/RuntimeProfiler.php
+++ b/src/Labrador/Development/RuntimeProfiler.php
@@ -40,8 +40,4 @@ class RuntimeProfiler {
         return $memory / 1024 / 1024;
     }
 
-
-
-
-
-} 
+}

--- a/src/Labrador/Service/DefaultServicesRegister.php
+++ b/src/Labrador/Service/DefaultServicesRegister.php
@@ -39,7 +39,6 @@ class DefaultServicesRegister implements Register {
         $this->registerLabradorServices($injector);
         $this->registerFastRouteServices($injector);
         $this->registerSymfonyServices($injector);
-        $injector->share(MasterConfig::class);
     }
 
     private function registerLabradorServices(Injector $injector) {

--- a/src/LabradorGuide/Service/ControllerRegister.php
+++ b/src/LabradorGuide/Service/ControllerRegister.php
@@ -9,27 +9,27 @@
 
 namespace LabradorGuide\Service;
 
+use Configlet\Config;
+use Labrador\ConfigDirective;
 use LabradorGuide\Controller\HomeController;
-use Auryn\Injector;
 use Labrador\Renderer;
 use Labrador\Service\Register;
+use Auryn\Injector;
 
 class ControllerRegister implements Register {
 
-    private $docDir;
     private $templatesDir;
 
-    function __construct($templatesDir, $docDir) {
-        $this->templatesDir = $templatesDir;
-        $this->docDir = $docDir;
+    function __construct(Config $config) {
+        $this->templatesDir = $config[ConfigDirective::ROOT_DIR] . '/src/LabradorGuide/_templates';
     }
 
     function register(Injector $injector) {
         $injector->share(Renderer::class);
         $injector->define(Renderer::class, [
-           ':templatesDir' => $this->templatesDir
+            ':templatesDir' => $this->templatesDir
         ]);
         $injector->share(HomeController::class);
     }
 
-} 
+}


### PR DESCRIPTION
The idea behind this is that /config/bootstrap.php should hold a
minimum of things to get the application and environment in a state
that it can handle a request. Features provided by Labrador, like the
guide and development tools, should be handled as middleware to allow
users to easily remove those features as needed.

tl;dr

/config/bootstrap.php is for critical steps in getting the app setup.
Features belong in middleware.
