### PR TITLE
Add ResolverChain to expand allowed handler types

### DIFF
--- a/src/Labrador/Application.php
+++ b/src/Labrador/Application.php
@@ -149,6 +149,7 @@ class Application implements HttpKernelInterface {
                 $cb = $this->triggerRouteFoundEvent($request);
                 $response = $this->executeController($request, $cb);
             }
+            $response = $this->triggerApplicationFinishedEvent($request, $response);
         } catch (PhpException $exc) {
             $code = ($exc instanceof HttpException) ? $exc->getCode() : Response::HTTP_INTERNAL_SERVER_ERROR;
 
@@ -158,9 +159,10 @@ class Application implements HttpKernelInterface {
                 throw $exc;
             }
             $response = $this->handleCaughtException($request, $exc, $code);
+            $response = $this->triggerApplicationFinishedEvent($request, $response);
         }
 
-        $response = $this->triggerApplicationFinishedEvent($request, $response);
+
         return $response;
     }
 

--- a/src/Labrador/Development/HtmlToolbar.php
+++ b/src/Labrador/Development/HtmlToolbar.php
@@ -84,7 +84,7 @@ CSS;
     private function getToolbarTemplate() {
         $memory = number_format($this->runtimeProfiler->getPeakMemoryUsage(), 3);
         $totalTime = number_format($this->runtimeProfiler->getTotalTimeElapsed(), 3);
-        $handler = $this->requestStack->getMasterRequest()->attributes->get('_labrador')['handler'];
+        $handler = var_export($this->requestStack->getMasterRequest()->attributes->get('_labrador')['handler'], true);
         $branch = $this->gitBranch->getBranchName();
         return <<<HTML
 <section id="labrador-dev-toolbar">

--- a/src/Labrador/Router/CallableHandlerResolver.php
+++ b/src/Labrador/Router/CallableHandlerResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * 
+ * @license See LICENSE in source root
+ * @version 1.0
+ * @since   1.0
+ */
+
+namespace Labrador\Router;
+
+
+class CallableHandlerResolver implements HandlerResolver {
+
+    function resolve($handler) {
+        if (is_callable($handler)) {
+            return $handler;
+        }
+
+        return false;
+    }
+
+}

--- a/src/Labrador/Router/HandlerResolver.php
+++ b/src/Labrador/Router/HandlerResolver.php
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * Should convert a routed handler into an appropriate callable function that
- * accepts a Request object as the only argument.
+ * Should convert a routed handler into an appropriate callable function.
  * 
  * @license See LICENSE in source root
  * @version 1.0
@@ -14,9 +13,11 @@ namespace Labrador\Router;
 interface HandlerResolver {
 
     /**
+     *
+     *
      * @param mixed $handler
-     * @return callable
-     * @throws \Labrador\Exception\Exception
+     * @return callable|false
+     * @throws \Labrador\Exception\InvalidHandlerException
      */
     function resolve($handler);
 

--- a/src/Labrador/Router/ResolverChain.php
+++ b/src/Labrador/Router/ResolverChain.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * 
+ * @license See LICENSE in source root
+ * @version 1.0
+ * @since   1.0
+ */
+
+namespace Labrador\Router;
+
+class ResolverChain implements HandlerResolver {
+
+    /**
+     * @property HandlerResolver[]
+     */
+    private $resolvers = [];
+
+    function resolve($handler) {
+        foreach ($this->resolvers as $resolver) {
+            $cb = $resolver->resolve($handler);
+            if ($cb) {
+                return $cb;
+            }
+        }
+
+        return false;
+    }
+
+    function add(HandlerResolver $resolver) {
+        $this->resolvers[] = $resolver;
+        return $this;
+    }
+
+    function remove(HandlerResolver $resolver) {
+        foreach($this->resolvers as $index => $stored) {
+            if ($resolver === $stored) {
+                unset($this->resolvers[$index]);
+            }
+        }
+
+        return $this;
+    }
+
+}

--- a/src/Labrador/Router/ServiceHandlerResolver.php
+++ b/src/Labrador/Router/ServiceHandlerResolver.php
@@ -40,7 +40,9 @@ class ServiceHandlerResolver implements HandlerResolver {
      * @throws InvalidHandlerException
      */
     function resolve($handler) {
-        $this->verifyFormat($handler);
+        if (!$this->verifyFormat($handler)) {
+            return false;
+        }
         list($controllerName, $action) = explode('#', $handler);
         try {
             $controller = $this->injector->make($controllerName);
@@ -62,9 +64,10 @@ class ServiceHandlerResolver implements HandlerResolver {
         // intentionally not checking for strict boolean false
         // we don't want to accept handlers that begin with #
         if (!strpos($handler, '#')) {
-            $msg = $this->errorMsg['invalid_handler_format'];
-            throw new InvalidHandlerException(sprintf($msg, $handler));
+            return false;
         }
+
+        return true;
     }
 
 } 

--- a/src/Labrador/Services.php
+++ b/src/Labrador/Services.php
@@ -15,6 +15,8 @@ use Labrador\Service\Register;
 use Labrador\Router\FastRouteRouter;
 use Labrador\Router\Router;
 use Labrador\Router\HandlerResolver;
+use Labrador\Router\ResolverChain;
+use Labrador\Router\CallableHandlerResolver;
 use Labrador\Router\ServiceHandlerResolver;
 use Auryn\Injector;
 use FastRoute\RouteCollector;
@@ -55,9 +57,12 @@ class Services implements Register {
         );
         $injector->alias(Router::class, FastRouteRouter::class);
 
-        $injector->share(ServiceHandlerResolver::class);
-        $injector->define(ServiceHandlerResolver::class, [ ':injector' => $injector]);
-        $injector->alias(HandlerResolver::class, ServiceHandlerResolver::class);
+        $injector->share(ResolverChain::class);
+        $injector->prepare(ResolverChain::class, function(ResolverChain $chain, Injector $injector) {
+            $chain->add($injector->make(CallableHandlerResolver::class))
+                  ->add($injector->make(ServiceHandlerResolver::class, [ ':injector' => $injector]));
+        });
+        $injector->alias(HandlerResolver::class, ResolverChain::class);
     }
 
     /**

--- a/test/Labrador/Test/Unit/CallableHandlerResolverTest.php
+++ b/test/Labrador/Test/Unit/CallableHandlerResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * 
+ * @license See LICENSE in source root
+ * @version 1.0
+ * @since   1.0
+ */
+
+namespace Labrador\Test\Unit;
+
+use Labrador\Router\CallableHandlerResolver;
+use PHPUnit_Framework_TestCase as UnitTestCase;
+
+class CallableHandlerResolverTest extends UnitTestCase {
+
+    function testHandlerIsCallableReturnsHandler() {
+        $resolver = new CallableHandlerResolver();
+        $closure = function() {};
+
+        $this->assertSame($closure, $resolver->resolve($closure));
+    }
+
+    function testHandlerIsNotCallableReturnsFalse() {
+        $resolver = new CallableHandlerResolver();
+
+        $this->assertFalse($resolver->resolve('not_callable#action'));
+    }
+
+} 

--- a/test/Labrador/Test/Unit/ResolverChainTest.php
+++ b/test/Labrador/Test/Unit/ResolverChainTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * 
+ * @license See LICENSE in source root
+ * @version 1.0
+ * @since   1.0
+ */
+
+namespace Labrador\Test\Unit;
+
+use Labrador\Router\ResolverChain;
+use PHPUnit_Framework_TestCase as UnitTestCase;
+
+class ResolverChainTest extends UnitTestCase {
+
+    function testExecutingChainCorrectly() {
+        $chain = new ResolverChain();
+
+        $closure = function() {};
+        $foo = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $foo->expects($this->once())->method('resolve')->will($this->returnValue(false));
+        $bar = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $bar->expects($this->once())->method('resolve')->will($this->returnValue($closure));
+        $qux = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $qux->expects($this->never())->method('resolve');
+
+        $chain->add($foo)->add($bar)->add($qux);
+
+        $this->assertSame($closure, $chain->resolve('handler'));
+    }
+
+    function testReturnFalseIfAllResolversFail() {
+        $chain = new ResolverChain();
+
+        $foo = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $foo->expects($this->once())->method('resolve')->will($this->returnValue(false));
+        $bar = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $bar->expects($this->once())->method('resolve')->will($this->returnValue(false));
+        $qux = $this->getMock('Labrador\\Router\\HandlerResolver');
+        $qux->expects($this->once())->method('resolve')->will($this->returnValue(false));
+
+        $chain->add($foo)->add($bar)->add($qux);
+
+        $this->assertFalse($chain->resolve('handler'));
+    }
+
+} 

--- a/test/Labrador/Test/Unit/ServiceHandlerResolverTest.php
+++ b/test/Labrador/Test/Unit/ServiceHandlerResolverTest.php
@@ -9,22 +9,18 @@
 
 namespace Labrador\Test\Unit;
 
-use Auryn\Provider;
 use Labrador\Router\ServiceHandlerResolver;
+use Auryn\Provider;
 use PHPUnit_Framework_TestCase as UnitTestCase;
 
 class ServiceHandlerResolverTest extends UnitTestCase {
 
-    function testNoHashTagInHandlerThrowsException() {
+    function testNoHashTagInHandlerReturnsFalse() {
         $handler = 'something_no_hashtag';
         $provider = new Provider();
         $resolver = new ServiceHandlerResolver($provider);
 
-        $this->setExpectedException(
-            'Labrador\\Exception\\InvalidHandlerException',
-            'The handler, something_no_hashtag, is invalid; all handlers must have 1 hashtag delimiting the controller and action.'
-        );
-        $resolver->resolve($handler);
+        $this->assertFalse($resolver->resolve($handler));
     }
 
     function testNoClassThrowsException() {


### PR DESCRIPTION
Adds more flexibility to the existing handler resolver services by
allowing a chain of resolvers to be run to determine which is best
suited to create a callable from the configured $handler. We also
provide callback handler to support use cases where the $handler is an
anonymous function.
