### PR TITLE
Now handles false resolver match properly

### DIFF
--- a/src/Labrador/Application.php
+++ b/src/Labrador/Application.php
@@ -174,6 +174,10 @@ class Application implements HttpKernelInterface {
     private function triggerRouteFoundEvent(Request $request) {
         $handler = $this->router->match($request);
         $cb = $this->resolver->resolve($handler);
+        if (!is_callable($cb)) {
+            $msg = 'An error was encountered resolving a found handler matching %s %s';
+            throw new ServerErrorException(sprintf($msg, $request->getMethod(), $request->getPathInfo()));
+        }
         $event = new RouteFoundEvent($request, $cb);
         $this->eventDispatcher->dispatch(Events::ROUTE_FOUND, $event);
         return $event->getController();

--- a/test/Labrador/Test/Unit/ApplicationTest.php
+++ b/test/Labrador/Test/Unit/ApplicationTest.php
@@ -99,6 +99,27 @@ class ApplicationTest extends UnitTestCase {
         $this->assertSame('Fatal error creating the requested handler', $response->getContent());
     }
 
+    function testResolverReturnsFalseIsServerErrorResponse() {
+        $request = Request::create('http://www.lbardor.dev');
+
+        $this->router->expects($this->once())
+                     ->method('match')
+                     ->with($request)
+                     ->will($this->returnValue('handler#action'));
+
+        $this->resolver->expects($this->once())
+                       ->method('resolve')
+                       ->with('handler#action')
+                       ->will($this->returnValue(false));
+
+        $app = $this->createApplication();
+        $response = $app->handle($request);
+        $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame('An error was encountered resolving a found handler matching GET /', $response->getContent());
+
+    }
+
     function testControllerMustReturnResponse() {
         $request = Request::create('http://www.labrador.dev');
         $handler = 'handler#action';


### PR DESCRIPTION
With the recent change to allowing false from HandlerResolver we introduced a logical bug in Labrador\Application. Because it was assuming that Resolvers would always return a callable or throw an exception it was blindly passing the `HandlerResolver::match` return value to `RouteFoundEvent` and triggering said event, even though the handler may not have been resolved into an appropriate callable. Not only was this resulting in a fatal error because of a mismatched typehint but it is also a flaw in Labrador's domain logic as RouteFoundEvent should only be triggered when the Router can match the Request and the HandlerResolver can turn it into an executable.
