### PR TITLE
Refactor Plugin interfaces and miscellaneous updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.0.0 - 2016-??-??
+
+- **BC BREAK** Removes the `Plugin::boot` method and introduces a new `BootablePlugin` interface. In practice very few
+  Plugins actually needed to use the `boot` method. If your Plugin *does*  make use of this method you'll need to make 
+  sure that you implement this new interface otherwise your Plugin **WILL NOT** boot. If you *don't* make use of this 
+  method you can now remove the useless code from your codebase.
+- Updates Auryn to 1.4.0
+- Updates Whoops to 2.1.0
+- Fixes deprecated uses of `setExpectedException` in test suite.
+
 ## v1.2.1 - 2016-03-13
 
 - Updates Auryn to 1.2.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Labrador
+# Labrador Core
 
 [![Travis](https://travis-ci.org/labrador-kennel/core.svg?branch=master)](https://travis-ci.org/labrador-kennel/core)
 [![Scrutinizer Coverage](https://img.shields.io/scrutinizer/coverage/g/labrador-kennel/core.svg?style=flat-square)](https://scrutinizer-ci.com/g/labrador-kennel/core/)
 [![GitHub license](https://img.shields.io/github/license/labrador-kennel/core.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/labrador-kennel/core.svg?style=flat-square)](https://github.com/cspray/labrador/releases/latest)
+[![Dependency Status](https://www.versioneye.com/user/projects/56ee922735630e0029dafb5f/badge.svg?style=flat)](https://www.versioneye.com/user/projects/56ee922735630e0029dafb5f)
 
 A minimalist PHP 7.0+ library that provides core "modules" to facilitate creating small-to-medium sized PHP 
 applications.
@@ -11,7 +12,7 @@ applications.
 - **Data Structures** Provided through the [Ardent](https://github.com/morrisonlevi/Ardent) library.
 - **IoC Container** Provided through the [Auryn](https://github.com/rdlowrey/Auryn) library.
 - **Events** Provided through [The PHP League Event](https://github.com/thephpleague/event) library.
-- **Plugins** A series of simple to implement interfaces provided by Labrador. Plugins can register services to the IoC container, attach callbacks to events and perform bootup actions.
+- **Plugins** A series of simple to implement interfaces provided by Labrador. Plugins can register services to the IoC container, attach callbacks to events, perform bootup actions, and depend on other Plugins!
 - **Engines** A service that ties events and plugins together to execute your application's primary logic.
 
 You can checkout a "Hello World" example below to get started quickly.

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": "~7.0",
-        "rdlowrey/auryn": "1.2.0",
+        "rdlowrey/auryn": "~1.4",
         "league/event": "~2.1",
         "morrisonlevi/ardent": "~0.20",
-        "filp/whoops": "~2.0.0"
+        "filp/whoops": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.2.5"
+        "phpunit/phpunit": "5.2.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3b1f428a9180630e763599703d370a02",
-    "content-hash": "9c0083c969f00404740164752e4999bb",
+    "hash": "59d23a3e2d2c043a1111e940ffbc5905",
+    "content-hash": "49d5e066800c7d46684a1f9dc58a1776",
     "packages": [
         {
             "name": "filp/whoops",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a327942c50cbd62b25c6fbe08f173031ce25fbff"
+                "reference": "8da9523f07c62d56fe1cf36f8ae29b333afc181f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a327942c50cbd62b25c6fbe08f173031ce25fbff",
-                "reference": "a327942c50cbd62b25c6fbe08f173031ce25fbff",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/8da9523f07c62d56fe1cf36f8ae29b333afc181f",
+                "reference": "8da9523f07c62d56fe1cf36f8ae29b333afc181f",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,8 @@
             },
             "require-dev": {
                 "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^4.8 || ^5.0",
+                "symfony/var-dumper": "~3.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -64,7 +65,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2016-01-06 17:51:21"
+            "time": "2016-03-13 10:22:39"
         },
         {
             "name": "league/event",
@@ -174,16 +175,16 @@
         },
         {
             "name": "rdlowrey/auryn",
-            "version": "1.2",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rdlowrey/auryn.git",
-                "reference": "d6e03a7026a1724965c921f4fbd8351ab8f0a9f1"
+                "reference": "2e4240791162dfe073d59654d8dc06df0eb0b73f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rdlowrey/auryn/zipball/d6e03a7026a1724965c921f4fbd8351ab8f0a9f1",
-                "reference": "d6e03a7026a1724965c921f4fbd8351ab8f0a9f1",
+                "url": "https://api.github.com/repos/rdlowrey/auryn/zipball/2e4240791162dfe073d59654d8dc06df0eb0b73f",
+                "reference": "2e4240791162dfe073d59654d8dc06df0eb0b73f",
                 "shasum": ""
             },
             "require": {
@@ -231,7 +232,7 @@
                 "dic",
                 "ioc"
             ],
-            "time": "2015-12-09 16:44:14"
+            "time": "2016-03-14 20:10:19"
         }
     ],
     "packages-dev": [
@@ -685,16 +686,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.2.5",
+            "version": "5.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "db79855b229d4bbcdc055ad74c5dc20ad3f5c5fe"
+                "reference": "6f0948bab32270352f97d1913d82a49338dcb0da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/db79855b229d4bbcdc055ad74c5dc20ad3f5c5fe",
-                "reference": "db79855b229d4bbcdc055ad74c5dc20ad3f5c5fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6f0948bab32270352f97d1913d82a49338dcb0da",
+                "reference": "6f0948bab32270352f97d1913d82a49338dcb0da",
                 "shasum": ""
             },
             "require": {
@@ -704,9 +705,9 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "myclabs/deep-copy": "~1.3",
-                "php": ">=5.6",
+                "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~3.2",
+                "phpunit/php-code-coverage": "^3.3.0",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": ">=1.0.6",
@@ -755,7 +756,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-02-13 06:58:29"
+            "time": "2016-03-15 05:59:58"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/src/Plugin/BootablePlugin.php
+++ b/src/Plugin/BootablePlugin.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * An interface for a plugin that needs to perform some action when the Engine boots up.
+ * 
+ * @license See LICENSE file in project root
+ */
+
+namespace Cspray\Labrador\Plugin;
+
+interface BootablePlugin extends Plugin {
+
+    /**
+     * Perform any actions that should be completed by your Plugin before the
+     * primary execution of your app is kicked off.
+     */
+    public function boot();
+
+}

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -3,21 +3,17 @@
 declare(strict_types=1);
 
 /**
- * Objects that interact with the Labrador engine or an application written on top
- * of Labrador; primarily this will involve making use of the EventAwarePlugin and
- * ServiceAwarePlugin interfaces to respond to triggered events or provide services.
+ * An identifying interface for objects that extend or hook into Labrador provided functionality; typically you would
+ * not implement this interface directly but implement one of the interfaces that extend Plugin.
  *
  * @license See LICENSE in source root
+ * 
+ * @see \Cspray\Labrador\Plugin\BootablePlugin
+ * @see \Cspray\Labrador\Plugin\EventAwarePlugin
+ * @see \Cspray\Labrador\Plugin\PluginDependentPlugin
+ * @see \Cspray\Labrador\Plugin\ServiceAwarePlugin
  */
 
 namespace Cspray\Labrador\Plugin;
 
-interface Plugin {
-
-    /**
-     * Perform any actions that should be completed by your Plugin before the
-     * primary execution of your app is kicked off.
-     */
-    public function boot();
-
-}
+interface Plugin {}

--- a/src/PluginManager.php
+++ b/src/PluginManager.php
@@ -12,8 +12,19 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador;
 
-use Cspray\Labrador\Plugin\{Pluggable, Plugin, ServiceAwarePlugin, EventAwarePlugin, PluginDependentPlugin};
-use Cspray\Labrador\Exception\{CircularDependencyException, NotFoundException, PluginDependencyNotProvidedException};
+use Cspray\Labrador\Plugin\{
+    BootablePlugin,
+    Pluggable,
+    Plugin,
+    ServiceAwarePlugin,
+    EventAwarePlugin,
+    PluginDependentPlugin
+};
+use Cspray\Labrador\Exception\{
+    CircularDependencyException,
+    NotFoundException,
+    PluginDependencyNotProvidedException
+};
 use Auryn\Injector;
 use Ardent\Collection\HashMap;
 use League\Event\EmitterInterface;
@@ -108,8 +119,9 @@ class PluginManager implements Pluggable {
                     $this->handlePluginDependencies($plugin);
                     $this->handlePluginServices($plugin);
                     $this->handlePluginEvents($plugin);
-                    $plugin->boot();
+                    $this->bootPlugin($plugin);
                     $this->finishLoading($plugin);
+
                 }
             }
 
@@ -158,6 +170,12 @@ class PluginManager implements Pluggable {
             private function handlePluginEvents(Plugin $plugin) {
                 if ($plugin instanceof EventAwarePlugin) {
                     $plugin->registerEventListeners($this->emitter);
+                }
+            }
+
+            private function bootPlugin(Plugin $plugin) {
+                if ($plugin instanceof BootablePlugin) {
+                    $plugin->boot();
                 }
             }
         };

--- a/test/PluginManagerTest.php
+++ b/test/PluginManagerTest.php
@@ -79,7 +79,10 @@ class PluginManagerTest extends UnitTestCase {
     public function testGettingUnregisteredPluginThrowsException() {
         $manager = $this->getPluginManager();
         $msg = 'Could not find a registered plugin named "%s"';
-        $this->setExpectedException(NotFoundException::class, sprintf($msg, PluginStub::class));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf($msg, PluginStub::class));
+
         $manager->getPlugin(PluginStub::class);
     }
 
@@ -120,7 +123,6 @@ class PluginManagerTest extends UnitTestCase {
 
         $engine = $this->getMockBuilder(Engine::class)->disableOriginalConstructor()->getMock();
 
-        $env = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $eventDispatcher->emit(Engine::ENGINE_BOOTUP_EVENT, [new EngineBootupEvent(), $engine]);
         $this->assertTrue($plugin->wasCalled());
     }
@@ -175,7 +177,10 @@ class PluginManagerTest extends UnitTestCase {
 
         $exc = CircularDependencyException::class;
         $msg = "A circular dependency was found with Cspray\\Labrador\\Test\\Stub\\RequiresCircularDependentStub requiring Cspray\\Labrador\\Test\\Stub\\CircularDependencyPluginStub.";
-        $this->setExpectedException($exc, $msg);
+
+        $this->expectException($exc);
+        $this->expectExceptionMessage($msg);
+
         $booter->bootPlugins();
     }
 
@@ -188,7 +193,9 @@ class PluginManagerTest extends UnitTestCase {
 
         $exc = PluginDependencyNotProvidedException::class;
         $msg = 'Cspray\\Labrador\\Test\\Stub\\RequiresNotPresentPlugin requires a plugin that is not registered: SomeAwesomePlugin.';
-        $this->setExpectedException($exc, $msg);
+
+        $this->expectException($exc);
+        $this->expectExceptionMessage($msg);
 
         $booter->bootPlugins();
     }

--- a/test/Stub/BootCalledPlugin.php
+++ b/test/Stub/BootCalledPlugin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * 
+ *
  * @license See LICENSE in source root
  * @version 1.0
  * @since   1.0
@@ -9,9 +9,9 @@
 
 namespace Cspray\Labrador\Test\Stub;
 
-use Cspray\Labrador\Plugin\Plugin;
+use Cspray\Labrador\Plugin\BootablePlugin;
 
-class BootCalledPlugin implements Plugin {
+class BootCalledPlugin implements BootablePlugin {
 
     private $bootCalled = false;
 
@@ -23,4 +23,4 @@ class BootCalledPlugin implements Plugin {
         $this->bootCalled = true;
     }
 
-} 
+}

--- a/test/Stub/CircularDependencyPluginStub.php
+++ b/test/Stub/CircularDependencyPluginStub.php
@@ -13,14 +13,6 @@ use Cspray\Labrador\Plugin\PluginDependentPlugin;
 class CircularDependencyPluginStub implements PluginDependentPlugin {
 
     /**
-     * Perform any actions that should be completed by your Plugin before the
-     * primary execution of your app is kicked off.
-     */
-    public function boot() {
-
-    }
-
-    /**
      * Return an array of plugin names that this plugin depends on.
      *
      * @return array

--- a/test/Stub/EventsRegisteredPlugin.php
+++ b/test/Stub/EventsRegisteredPlugin.php
@@ -23,11 +23,4 @@ class EventsRegisteredPlugin implements EventAwarePlugin {
         $this->called = true;
     }
 
-    /**
-     * Perform any actions that should be
-     */
-    public function boot() {
-        // TODO: Implement boot() method.
-    }
-
 }

--- a/test/Stub/FooPluginDependentStub.php
+++ b/test/Stub/FooPluginDependentStub.php
@@ -8,11 +8,11 @@ declare(strict_types = 1);
 
 namespace Cspray\Labrador\Test\Stub;
 
-use Cspray\Labrador\Plugin\PluginDependentPlugin;
+use Cspray\Labrador\Plugin\{BootablePlugin, PluginDependentPlugin};
 use Auryn\Injector;
 
 
-class FooPluginDependentStub implements PluginDependentPlugin {
+class FooPluginDependentStub implements PluginDependentPlugin, BootablePlugin {
 
     private $injector;
     private $dependsOnProvided;

--- a/test/Stub/FooPluginStub.php
+++ b/test/Stub/FooPluginStub.php
@@ -8,10 +8,10 @@ declare(strict_types = 1);
 
 namespace Cspray\Labrador\Test\Stub;
 
-use Cspray\Labrador\Plugin\ServiceAwarePlugin;
+use Cspray\Labrador\Plugin\{BootablePlugin, ServiceAwarePlugin};
 use Auryn\Injector;
 
-class FooPluginStub implements ServiceAwarePlugin {
+class FooPluginStub implements ServiceAwarePlugin, BootablePlugin {
 
     private $numBootCalled = 0;
 

--- a/test/Stub/PluginStub.php
+++ b/test/Stub/PluginStub.php
@@ -12,8 +12,4 @@ use Cspray\Labrador\Plugin\Plugin;
 
 class PluginStub implements Plugin {
 
-    public function boot() {
-
-    }
-
 }

--- a/test/Stub/RecursivelyDependentPluginStub.php
+++ b/test/Stub/RecursivelyDependentPluginStub.php
@@ -8,10 +8,10 @@ declare(strict_types = 1);
 
 namespace Cspray\Labrador\Test\Stub;
 
-use Cspray\Labrador\Plugin\PluginDependentPlugin;
+use Cspray\Labrador\Plugin\{BootablePlugin, PluginDependentPlugin};
 use Auryn\Injector;
 
-class RecursivelyDependentPluginStub implements PluginDependentPlugin {
+class RecursivelyDependentPluginStub implements PluginDependentPlugin, BootablePlugin {
 
     private $injector;
     private $dependsOnProvided;

--- a/test/Stub/RequiresCircularDependentStub.php
+++ b/test/Stub/RequiresCircularDependentStub.php
@@ -13,14 +13,6 @@ use Cspray\Labrador\Plugin\PluginDependentPlugin;
 class RequiresCircularDependentStub implements PluginDependentPlugin {
 
     /**
-     * Perform any actions that should be completed by your Plugin before the
-     * primary execution of your app is kicked off.
-     */
-    public function boot() {
-
-    }
-
-    /**
      * Return an array of plugin names that this plugin depends on.
      *
      * @return array

--- a/test/Stub/RequiresNotPresentPlugin.php
+++ b/test/Stub/RequiresNotPresentPlugin.php
@@ -13,14 +13,6 @@ use Cspray\Labrador\Plugin\PluginDependentPlugin;
 class RequiresNotPresentPlugin implements PluginDependentPlugin {
 
     /**
-     * Perform any actions that should be completed by your Plugin before the
-     * primary execution of your app is kicked off.
-     */
-    public function boot() {
-        // noop
-    }
-
-    /**
      * Return an array of plugin names that this plugin depends on.
      *
      * @return array

--- a/test/Stub/ServicesRegisteredPlugin.php
+++ b/test/Stub/ServicesRegisteredPlugin.php
@@ -16,13 +16,6 @@ class ServicesRegisteredPlugin implements ServiceAwarePlugin {
     }
 
     /**
-     * Perform any actions that should be
-     */
-    public function boot() {
-        // TODO: Implement boot() method.
-    }
-
-    /**
      * Register any services that the Plugin provides.
      *
      * @param Injector $injector


### PR DESCRIPTION
- Removes the 'boot' method from the Plugin interface and introduces a
  new BootablePlugin interface. Any Plugin that needs to perform a
  one-time action when the Engine is booted will need to implement this
  interface.

- Updates deprecated uses of PHPUnit's setExpectedException

- Updates several dependencies