### PR TITLE
Refactor BootablePlugin::boot to be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 3.0.0-beta4 2019-05-11
+
+The previous 3.0 Release Candidate has been found lacking key features that should be implemented for 
+a stable release. The codebase will become more stable before a 2nd RC is released.
+
+#### Added
+
+- A new method `Pluggable::loadPlugins` that must be explicitly called to load Plugins. Additionally, 
+this method is expected to be asynchronous to take advantage of async Plugin booting.
+
+#### Changed
+
+- Refactors the `Bootable::boot` method to return a callable that can be invoked in context of the 
+event loop, meaning you can yield Promises etc, and has all dependencies resolved with your Injector.
+- Refactors the Pluggable::registerPlugin method to return void and to throw an exception if a Plugin
+is attempted to be registered after `Pluggable::loadPlugins` is called.
+- Changed the `InvalidEngineStateException` to an `InvalidStateException` to be more generic and 
+used in multiple places.
+
 ## 3.0.0-rc1 - 2019-02-16
 
 #### Added

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "rdlowrey/auryn": "~1.4"
   },
   "require-dev": {
-    "amphp/phpunit-util": "~1.0",
+    "amphp/phpunit-util": "dev-master",
     "cspray/labrador-coding-standard": "0.1.0",
     "phpunit/phpunit": "~6.5"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ede77829c0669a3aa340e9acdf8fdf6c",
+    "content-hash": "879b81414b1e456d617ef29cc838f9e6",
     "packages": [
         {
             "name": "amphp/amp",
@@ -237,23 +237,24 @@
     "packages-dev": [
         {
             "name": "amphp/phpunit-util",
-            "version": "v1.0.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/phpunit-util.git",
-                "reference": "1194636f5f1796d03e4e59c219cd3abfffe40eb8"
+                "reference": "f5a47f220813b896f6046bd21bf43804f70f13a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/phpunit-util/zipball/1194636f5f1796d03e4e59c219cd3abfffe40eb8",
-                "reference": "1194636f5f1796d03e4e59c219cd3abfffe40eb8",
+                "url": "https://api.github.com/repos/amphp/phpunit-util/zipball/f5a47f220813b896f6046bd21bf43804f70f13a5",
+                "reference": "f5a47f220813b896f6046bd21bf43804f70f13a5",
                 "shasum": ""
             },
             "require": {
-                "phpunit/phpunit": "^6"
+                "phpunit/phpunit": "^6 | ^7 | ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2"
+                "amphp/amp": "^2",
+                "amphp/php-cs-fixer-config": "dev-master"
             },
             "type": "library",
             "autoload": {
@@ -269,11 +270,15 @@
                 {
                     "name": "Niklas Keller",
                     "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
                 }
             ],
             "description": "Helper package to ease testing with PHPUnit.",
             "homepage": "http://amphp.org/phpunit-util",
-            "time": "2017-06-15T15:43:56+00:00"
+            "time": "2019-03-14T20:56:01+00:00"
         },
         {
             "name": "cspray/labrador-coding-standard",
@@ -311,27 +316,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -356,25 +363,25 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -409,7 +416,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11T23:09:50+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -569,16 +576,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -616,7 +623,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1681,16 +1688,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -1723,25 +1730,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1760,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -1786,20 +1793,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
                 "shasum": ""
             },
             "require": {
@@ -1826,7 +1833,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-04-04T09:56:43+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1883,7 +1890,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "cspray/labrador-async-event": 5
+        "cspray/labrador-async-event": 5,
+        "amphp/phpunit-util": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -30,6 +30,7 @@ interface Engine extends Pluggable {
     /**
      * Execute the application's primary logic.
      *
+     * @param Application $application
      * @return void
      */
     public function run(Application $application) : void;

--- a/src/Exception/InvalidStateException.php
+++ b/src/Exception/InvalidStateException.php
@@ -8,5 +8,5 @@
  */
 namespace Cspray\Labrador\Exception;
 
-class InvalidEngineStateException extends Exception {
+class InvalidStateException extends Exception {
 }

--- a/src/Plugin/Pluggable.php
+++ b/src/Plugin/Pluggable.php
@@ -1,15 +1,41 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 /**
- * An interface for objects that allow Plugins to be attached or associated with them.
+ * Pluggable interface
  *
  * @license See LICENSE in source root
  */
 
 namespace Cspray\Labrador\Plugin;
 
+use Amp\Promise;
+use Cspray\Labrador\Exception\CircularDependencyException;
+use Cspray\Labrador\Exception\InvalidArgumentException;
+use Cspray\Labrador\Exception\InvalidStateException;
+use Cspray\Labrador\Exception\NotFoundException;
+
+/**
+ * An interface for objects that have Plugins associated to them and are responsible for manging the lifecycle of the
+ * Plugin for as long as it remains attached to the given Pluggable.
+ *
+ * The primary responsibility of a Pluggable is to ensure that the various hooks for a given Plugin type are invoked
+ * properly. The responsibility of invoking each Plugin type's hooks is left to a plugin handler; the Plugin types that
+ * exist within Labrador\Core\Plugin SHOULD have their plugin handlers be an implicit part of the Pluggable
+ * implementation. If your application requires custom Plugin hooks you should implement those with application specific
+ * code and taking advantage of registerPluginHandler.
+ *
+ * 1. Any dependencies should have this process completed if the registered Plugin is a PluginDependentPlugin. The
+ * process should detect for circular references and throw an exception if one is encountered.
+ * 2. If the registered Plugin is a ServiceAwarePlugin the Injector should be provided so that the object graph for the
+ * Plugin can be wired properly.
+ * 3. If the registered Plugin is an EventAwarePlugin the Emitter should be provided so that any listeners can be
+ * registered.
+ * 4. If the registered Plugin has any custom Plugin handlers each one should be invoked in the order it was registered.
+ * 5. Finally, if the registered Plugin is a BootablePlugin the callback from boot() should be invoked with the
+ * Injector::execute method.
+ *
+ * @package Cspray\Labrador\Plugin
+ */
 interface Pluggable {
 
     /**
@@ -25,10 +51,40 @@ interface Pluggable {
     public function registerPluginHandler(string $pluginType, callable $pluginHandler, ...$arguments) : void;
 
     /**
+     * Store the Plugin to prepare it for loading when Pluggable::loadPlugins() is called; typically in Labrador
+     * powered Applications this happens for you when the Engine::ENGINE_BOOTUP_EVENT is triggered.
+     *
+     * If the Plugin passed has already been registered throw an InvalidArgumentException as a Plugin MUST only be
+     * registered one time.
+     *
+     * If the Plugin is registered after the Plugglable::loadPlugins() event is called throw an InvalidStateException as
+     * all Plugins must be registered before they are loaded. This is necessary because loading Plugins requires the
+     * event loop be running, something we don't necessarily want to enforce simply for Plugin registration. It also is
+     * indicative of a poorly designed application as, specifically, the BootablePlugin::boot method is intended to
+     * run at initialization and could be designed in a way to be longer running than you would want once your app is
+     * serving clients.
+     *
      * @param Plugin $plugin
-     * @return $this
+     * @return void
+     * @throws InvalidArgumentException
+     * @throws InvalidStateException
      */
-    public function registerPlugin(Plugin $plugin) : Pluggable;
+    public function registerPlugin(Plugin $plugin) : void;
+
+    /**
+     * Go through the loading and booting process for all Plugins that have been registered to this Pluggable.
+     *
+     * This is a distinct operation separate from registering a Plugin so that you can ensure all PluginDependentPlugin
+     * dependencies are provided and to express the intent that the loadPlugins process is asynchronous and needs to be
+     * executed on an event loop.
+     *
+     * If Plugin A is being loaded and depends on Plugin B but Plugin B also depends on Plugin A you MUST throw a
+     * CircularDependencyException as the registered Plugins are invalid and cannot be properly loaded.
+     *
+     * @return Promise
+     * @throws CircularDependencyException
+     */
+    public function loadPlugins() : Promise;
 
     /**
      * @param string $name
@@ -44,6 +100,7 @@ interface Pluggable {
     /**
      * @param string $name
      * @return Plugin
+     * @throws NotFoundException
      */
     public function getPlugin(string $name) : Plugin;
 

--- a/src/StandardApplication.php
+++ b/src/StandardApplication.php
@@ -13,8 +13,9 @@ abstract class StandardApplication implements Application {
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        // noop, override in your Application to do something at boot time
+    public function boot() : callable {
+        return function() {
+        };
     }
 
     /**

--- a/test/AmpEngineTest.php
+++ b/test/AmpEngineTest.php
@@ -16,7 +16,7 @@ use Amp\Success;
 use Cspray\Labrador\Application;
 use Cspray\Labrador\Engine;
 use Cspray\Labrador\AmpEngine;
-use Cspray\Labrador\Exception\InvalidEngineStateException;
+use Cspray\Labrador\Exception\InvalidStateException;
 use Cspray\Labrador\PluginManager;
 use Cspray\Labrador\Exception\Exception;
 use Cspray\Labrador\Test\Stub\CallbackApplication;
@@ -39,16 +39,16 @@ class AmpEngineTest extends UnitTestCase {
      * @var Emitter
      */
     private $emitter;
-    private $mockPluginManager;
+    private $pluginManager;
 
     public function setUp() {
         $this->emitter = new AmpEmitter();
-        $this->mockPluginManager = $this->getMockBuilder(PluginManager::class)->disableOriginalConstructor()->getMock();
+        $this->pluginManager = new PluginManager(new Injector(), $this->emitter);
     }
 
     private function getEngine(Emitter $eventEmitter = null, PluginManager $pluginManager = null) : AmpEngine {
         $emitter = $eventEmitter ?: $this->emitter;
-        $manager = $pluginManager ?: $this->mockPluginManager;
+        $manager = $pluginManager ?: $this->pluginManager;
         return new AmpEngine($manager, $emitter);
     }
 
@@ -151,8 +151,7 @@ class AmpEngineTest extends UnitTestCase {
     }
 
     public function testRegisteredPluginsGetBooted() {
-        $pluginManager = new PluginManager($this->createMock(Injector::class), $this->emitter);
-        $engine = $this->getEngine($this->emitter, $pluginManager);
+        $engine = $this->getEngine($this->emitter, $this->pluginManager);
 
         $plugin = new BootCalledPlugin();
         $engine->registerPlugin($plugin);
@@ -259,7 +258,7 @@ class AmpEngineTest extends UnitTestCase {
         $app = $this->exceptionHandlerApp($appCb, $handlerCb);
         $engine->run($app);
 
-        $this->assertInstanceOf(InvalidEngineStateException::class, $data->data);
+        $this->assertInstanceOf(InvalidStateException::class, $data->data);
         $this->assertSame('Engine::run() MUST NOT be called while already running.', $data->data->getMessage());
     }
 

--- a/test/Stub/BootCalledPlugin.php
+++ b/test/Stub/BootCalledPlugin.php
@@ -19,7 +19,9 @@ class BootCalledPlugin implements BootablePlugin {
         return $this->bootCalled;
     }
 
-    public function boot() : void {
-        $this->bootCalled = true;
+    public function boot() : callable {
+        return function() {
+            $this->bootCalled = true;
+        };
     }
 }

--- a/test/Stub/CallbackApplication.php
+++ b/test/Stub/CallbackApplication.php
@@ -51,8 +51,9 @@ class CallbackApplication implements Application {
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        // noop
+    public function boot() : callable {
+        return function() {
+        };
     }
 
     /**

--- a/test/Stub/CustomPluginOrderStub.php
+++ b/test/Stub/CustomPluginOrderStub.php
@@ -22,8 +22,10 @@ class CustomPluginOrderStub implements BootablePlugin, EventAwarePlugin, Service
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot(): void {
-        $this->callOrder[] = 'boot';
+    public function boot(): callable {
+        return function() {
+            $this->callOrder[] = 'boot';
+        };
     }
 
     /**

--- a/test/Stub/FooPluginDependentStub.php
+++ b/test/Stub/FooPluginDependentStub.php
@@ -25,10 +25,12 @@ class FooPluginDependentStub implements PluginDependentPlugin, BootablePlugin {
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        $injectorInfo = $this->injector->inspect();
-        $shares = $injectorInfo[Injector::I_SHARES];
-        $this->dependsOnProvided = array_key_exists('cspray\labrador\test\stub\fooservice', $shares);
+    public function boot() : callable {
+        return function() {
+            $injectorInfo = $this->injector->inspect();
+            $shares = $injectorInfo[Injector::I_SHARES];
+            $this->dependsOnProvided = array_key_exists('cspray\labrador\test\stub\fooservice', $shares);
+        };
     }
 
     public function wasDependsOnProvided() {

--- a/test/Stub/FooPluginStub.php
+++ b/test/Stub/FooPluginStub.php
@@ -20,20 +20,16 @@ class FooPluginStub implements ServiceAwarePlugin, BootablePlugin {
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        $this->numBootCalled++;
+    public function boot() : callable {
+        return function() {
+            $this->numBootCalled++;
+        };
     }
 
     public function getNumberTimesBootCalled() : int {
         return $this->numBootCalled;
     }
 
-    /**
-     * Register any services that the Plugin provides.
-     *
-     * @param Injector $injector
-     * @return void
-     */
     public function registerServices(Injector $injector) : void {
         $injector->share(FooService::class);
     }

--- a/test/Stub/FooServiceBootablePlugin.php
+++ b/test/Stub/FooServiceBootablePlugin.php
@@ -1,16 +1,20 @@
 <?php
 
-declare(strict_types = 1);
 
-/**
- * An interface for a plugin that needs to perform some action when the Engine boots up.
- *
- * @license See LICENSE file in project root
- */
+namespace Cspray\Labrador\Test\Stub;
 
-namespace Cspray\Labrador\Plugin;
+use Auryn\Injector;
+use Cspray\Labrador\Plugin\BootablePlugin;
+use Cspray\Labrador\Plugin\ServiceAwarePlugin;
 
-interface BootablePlugin extends Plugin {
+class FooServiceBootablePlugin implements ServiceAwarePlugin, BootablePlugin {
+
+    private $fooService;
+    private $bootInjectedService;
+
+    public function __construct(FooService $fooService) {
+        $this->fooService = $fooService;
+    }
 
     /**
      * Return a callable that will be invoked using Auryn's Injector::execute API.
@@ -25,5 +29,17 @@ interface BootablePlugin extends Plugin {
      *
      * @return callable
      */
-    public function boot() : callable;
+    public function boot(): callable {
+        return function(FooService $fooService) {
+            $this->bootInjectedService = $fooService;
+        };
+    }
+
+    public function registerServices(Injector $injector): void {
+        $injector->share($this->fooService);
+    }
+
+    public function getBootInjectedService() {
+        return $this->bootInjectedService;
+    }
 }

--- a/test/Stub/GeneratorBooterPlugin.php
+++ b/test/Stub/GeneratorBooterPlugin.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+
+namespace Cspray\Labrador\Test\Stub;
+
+use Amp\Delayed;
+use Cspray\Labrador\Plugin\BootablePlugin;
+
+class GeneratorBooterPlugin implements BootablePlugin {
+
+    private $timesYielded = 0;
+
+    public function boot(): callable {
+        return function() {
+            yield new Delayed(1);
+            $this->timesYielded++;
+            yield new Delayed(1);
+            $this->timesYielded++;
+            yield new Delayed(1);
+            $this->timesYielded++;
+        };
+    }
+
+    public function getTimesYielded() : int {
+        return $this->timesYielded;
+    }
+}

--- a/test/Stub/NoopApplication.php
+++ b/test/Stub/NoopApplication.php
@@ -29,8 +29,9 @@ class NoopApplication implements Application {
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        // noop
+    public function boot() : callable {
+        return function() {
+        };
     }
 
     /**

--- a/test/Stub/RecursivelyDependentPluginStub.php
+++ b/test/Stub/RecursivelyDependentPluginStub.php
@@ -25,10 +25,12 @@ class RecursivelyDependentPluginStub implements PluginDependentPlugin, BootableP
      * Perform any actions that should be completed by your Plugin before the
      * primary execution of your app is kicked off.
      */
-    public function boot() : void {
-        $injectorInfo = $this->injector->inspect();
-        $shares = $injectorInfo[Injector::I_SHARES];
-        $this->dependsOnProvided = array_key_exists('cspray\labrador\test\stub\fooservice', $shares);
+    public function boot() : callable {
+        return function() {
+            $injectorInfo = $this->injector->inspect();
+            $shares = $injectorInfo[Injector::I_SHARES];
+            $this->dependsOnProvided = array_key_exists('cspray\labrador\test\stub\fooservice', $shares);
+        };
     }
 
     public function wasDependsOnProvided() {


### PR DESCRIPTION
- Changes the BootablePlugin::boot method to return a callable that can
be invoked by an Injector for dependency resolution and can be invoked
on the event loop. Many changes were necessary to facilitate moving from
a synchronous Plugin loading process to an asynchronous Plugin loading
process.