### PR TITLE
Fix schemas symlink

### DIFF
--- a/docs/schemas
+++ b/docs/schemas
@@ -1,1 +1,0 @@
-../resources/schemas/

--- a/docs/schemas/configuration.schema.json
+++ b/docs/schemas/configuration.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://labrador-kennel.cspray.io/schemas/configuration.schema.json",
+  "title": "Labrador Configuration",
+  "description": "Schema to ensure that a JSON based configuration provides valid values.",
+  "type": "object",
+  "properties": {
+    "labrador": {
+      "type": "object",
+      "properties": {
+        "logging": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of your application's logs",
+              "type": "string",
+              "minLength": 1
+            },
+            "outputPath": {
+              "description": "The resource path that your logs will stream to.",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "name",
+            "outputPath"
+          ]
+        },
+        "injectorProviderPath":  {
+          "description": "A file path that returns a callback that accepts a Configuration instance and returns an Injector.",
+          "type": "string"
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "logging",
+        "injectorProviderPath",
+        "plugins"
+      ]
+    }
+  },
+  "required": ["labrador"]
+}

--- a/docs/schemas/configuration.schema.xsd
+++ b/docs/schemas/configuration.schema.xsd
@@ -1,0 +1,27 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://labrador-kennel.io/core/schemas/configuration.schema.xsd"
+            elementFormDefault="qualified"
+>
+  <xsd:element name="labrador">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="logging">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element name="name" type="xsd:string" />
+              <xsd:element name="outputPath" type="xsd:string" />
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:element name="injectorProviderPath" type="xsd:string" />
+        <xsd:element name="plugins">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element name="plugin" type="xsd:string" maxOccurs="unbounded" />
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Jekyll has issues with symlinks that exist outside of the root directory
for your site. This fix simply copies over the schemas from the
resources/schemas directory into docs/schemas. A better solution should
be developed to not have duplicate files but it is desired to have these
schemas exist at the URL we use to define them.