### PR TITLE
Throw exceptions from AbstractApplication

### DIFF
--- a/src/AbstractApplication.php
+++ b/src/AbstractApplication.php
@@ -117,6 +117,7 @@ abstract class AbstractApplication implements Application {
      */
     public function handleException(Throwable $throwable) : void {
         $this->logException($throwable);
+        throw $throwable;
     }
 
     /**

--- a/test/AbstractApplicationTest.php
+++ b/test/AbstractApplicationTest.php
@@ -212,7 +212,6 @@ class AbstractApplicationTest extends AsyncTestCase {
         try {
             $this->subject->handleException($throwable);
         } catch (\RuntimeException $runtimeException) {
-
         }
 
         $expectedRecords = [
@@ -242,7 +241,6 @@ class AbstractApplicationTest extends AsyncTestCase {
         try {
             $this->subject->handleException($throwable);
         } catch (\RuntimeException $runtimeException) {
-
         }
 
         $expectedRecords = [

--- a/test/AbstractApplicationTest.php
+++ b/test/AbstractApplicationTest.php
@@ -197,10 +197,23 @@ class AbstractApplicationTest extends AsyncTestCase {
         $this->subject->start();
     }
 
+    public function testHandleExceptionRethrows() {
+        $throwable = new \RuntimeException();
+
+        $this->expectExceptionObject($throwable);
+
+        $this->subject->handleException($throwable);
+    }
+
     public function testHandleExceptionLogsErrorNoPreviousException() {
         $throwable = new \RuntimeException('Exception message', 99);
         $line = __LINE__ - 1;
-        $this->subject->handleException($throwable);
+
+        try {
+            $this->subject->handleException($throwable);
+        } catch (\RuntimeException $runtimeException) {
+
+        }
 
         $expectedRecords = [
             [
@@ -226,7 +239,11 @@ class AbstractApplicationTest extends AsyncTestCase {
         $throwable = new \RuntimeException('Exception message', 99, $second);
         $line = __LINE__ - 3;
 
-        $this->subject->handleException($throwable);
+        try {
+            $this->subject->handleException($throwable);
+        } catch (\RuntimeException $runtimeException) {
+
+        }
 
         $expectedRecords = [
             [


### PR DESCRIPTION
Unhandled exceptions could potentially result in squashed exceptions
based on the logger that was used for the Application. This changes the
default behavior to always rethrow the exception after logging... Each
Application implementation should define what exceptions it can handle
and which ones it can't.