### PR TITLE
Add initial signal watcher to kill app

### DIFF
--- a/src/AmpEngine.php
+++ b/src/AmpEngine.php
@@ -93,7 +93,9 @@ final class AmpEngine implements Engine {
             // emitEngineShutDownEvent throws an exception which would cause the Loop error handler to be called
             // again, which would cause the process powering our app to go into an infinite loop until maximum memory
             // is used.
-            Loop::disable($signalWatcher);
+            if (isset($signalWatcher)) {
+                Loop::disable($signalWatcher);
+            }
             if (!$this->engineState->isCrashed()) {
                 $this->engineState = EngineState::Crashed();
                 $application->handleException($error);
@@ -133,7 +135,9 @@ final class AmpEngine implements Engine {
             yield $this->emitEngineShutDownEvent($application);
             $this->logger->info('Completed Application cleanup process. Engine shutting down.');
             $this->engineState = EngineState::Idle();
-            Loop::disable($signalWatcher);
+            if (isset($signalWatcher)) {
+                Loop::disable($signalWatcher);
+            }
         });
     }
 

--- a/src/AmpEngine.php
+++ b/src/AmpEngine.php
@@ -77,6 +77,7 @@ final class AmpEngine implements Engine {
             throw $exception;
         }
 
+        $signalWatcher = null;
         if (Loop::get() instanceof Loop\NativeDriver && extension_loaded('pcntl')) {
             $signalWatcher = Loop::onSignal(SIGINT, function() use($application, &$signalWatcher) {
                 if ($this->engineState->isRunning()) {


### PR DESCRIPTION
In practice not responding to SIGINT caused end users to forcefully shut
down the underlying architecture running the application. This could
mean forcefully killing docker containers as oppoased to gracefully
handling exit requests. This submits an initial, untested,
implementation to watch for signals to quit the app.