### PR TITLE
Remove native driver check

### DIFF
--- a/src/AmpEngine.php
+++ b/src/AmpEngine.php
@@ -78,7 +78,7 @@ final class AmpEngine implements Engine {
         }
 
         $signalWatcher = null;
-        if (Loop::get() instanceof Loop\NativeDriver && extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl')) {
             $signalWatcher = Loop::onSignal(SIGINT, function() use($application, &$signalWatcher) {
                 if ($this->engineState->isRunning()) {
                     yield $application->stop();


### PR DESCRIPTION
After speaking with amp maintainers it is not realistic to expect that a signal will be processable without the pcntl extension, regardless of which Driver is used. Simplifies the check to allow signal processing for all drivers as long as pctnl is installed.